### PR TITLE
[OD-875] Added IE compatibility check for PDFJS Worker

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
+## [TICKET](https://opengovinc.atlassian.net/browse/XXX-999)
+
+## Description
+<!--- Describe these changes in detail --->
+
+
+## Test Procedure
+<!--- List the steps involved to test the changes --->
+
+## Approval Criteria
+<!--- Describe the expected results of testing --->
+
+## Submitter Checklist
+- [ ] I have tested the changes locally
+- [ ] The new changes does not affect web accessibility

--- a/ckanext/pdfview/theme/public/vendor/pdfjs/web/compatibility.js
+++ b/ckanext/pdfview/theme/public/vendor/pdfjs/web/compatibility.js
@@ -24,6 +24,20 @@ if (typeof PDFJS === 'undefined') {
   (typeof window !== 'undefined' ? window : this).PDFJS = {};
 }
 
+// Disable PDFJS Worker due to compatability issues associated w/ redirects & CORS
+// This impacts only Internet Explorer related browswers
+function pdfJSWorkerCompatabilityCheck() {
+    var ua = window.navigator.userAgent;
+    var msie = ua.indexOf('MSIE ');
+    var trident = ua.indexOf('Trident/');
+    var edge = ua.indexOf('Edge/');
+    if ( msie > 0 || trident > 0 || edge > 0 ){
+      PDFJS.disableWorker = true;
+    }
+}
+
+pdfJSWorkerCompatabilityCheck();
+
 // Checking if the typed arrays are supported
 // Support: iOS<6.0 (subarray), IE<10, Android<4.0
 (function checkTypedArrayCompatibility() {

--- a/ckanext/pdfview/theme/public/vendor/pdfjs/web/compatibility.js
+++ b/ckanext/pdfview/theme/public/vendor/pdfjs/web/compatibility.js
@@ -27,7 +27,7 @@ if (typeof PDFJS === 'undefined') {
 // Disable PDFJS Worker due to compatability issues associated w/ redirects & CORS
 // This impacts only Internet Explorer related browswers
 function pdfJSWorkerCompatabilityCheck() {
-    var ua = window.navigator.userAgent;
+    var ua = (typeof navigator !== 'undefined' && navigator.userAgent) || '';
     var msie = ua.indexOf('MSIE ');
     var trident = ua.indexOf('Trident/');
     var edge = ua.indexOf('Edge/');


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [[OD-875] Added IE compatibility check for PDFJS Worker](https://opengovinc.atlassian.net/browse/OD-875)

## Description
<!--- Describe these changes in detail --->
This PR adds a function in compatibility.js to check if the current browser is an iteration of IE (Internet Explorer, Edge, etc.). If the browser is an iteration of IE, we disable the PDFJS Worker which has compatibility issues with redirects & CORS, an example of this is a PDF on CKAN hosted on s3 failing to load because the pdf viewer fails to redirect to the s3 url.

## Test Procedure
<!--- List the steps involved to test the changes --->
- Apply this PR's changes on a sandbox environment
- Verify PDFs can be viewed in Internet Explorer 11, Firefox, and Chrome with no issues

## Approval Criteria 
<!--- Describe the expected results of testing --->

## Submitter Checklist
- [x] I have tested the changes locally
- [x] The new changes does not affect web accessibility
