### PR TITLE
[PA-573]Return "false" to can_view for Resourse without url

### DIFF
--- a/ckanext/pdfview/plugin.py
+++ b/ckanext/pdfview/plugin.py
@@ -44,6 +44,8 @@ class PdfView(p.SingletonPlugin):
         format_lower = resource.get('format', '').lower()
 
         proxy_enabled = p.plugin_loaded('resource_proxy')
+        if 'url' not in data_dict['resource']:
+            return False
         same_domain = datapreview.on_same_domain(data_dict)
 
         if format_lower in self.PDF:

--- a/ckanext/pdfview/plugin.py
+++ b/ckanext/pdfview/plugin.py
@@ -41,11 +41,11 @@ class PdfView(p.SingletonPlugin):
 
     def can_view(self, data_dict):
         resource = data_dict['resource']
+        if 'url' not in data_dict['resource']:
+            return False
         format_lower = resource.get('format', '').lower()
 
         proxy_enabled = p.plugin_loaded('resource_proxy')
-        if 'url' not in data_dict['resource']:
-            return False
         same_domain = datapreview.on_same_domain(data_dict)
 
         if format_lower in self.PDF:


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [TICKET](https://opengovinc.atlassian.net/browse/PA-573)

## Description
<!--- Describe these changes in detail --->
Return "false" to can_view for Resourse without url. This will solve the problem that harvest job stops because of resource missing url.

## Test Procedure
<!--- List the steps involved to test the changes --->
1.python setup.py develop
2.enable `pdf_view`,`dcat`, `dcat_json_harvester` and `dcat_json_interface` in ckan.ini plugins
3.create a harvest job using url: https://opendata-cosagis.opendata.arcgis.com/data.json
select source type "dcat"

## Approval Criteria
<!--- Describe the expected results of testing --->
-No error of url missing

## Submitter Checklist
- [ ] I have tested the changes locally
- [ ] The new changes does not affect web accessibility
