### PR TITLE
[PA-500]Notify admin of Large PDF

### DIFF
--- a/ckanext/pdfview/plugin.py
+++ b/ckanext/pdfview/plugin.py
@@ -2,6 +2,7 @@ import logging
 
 import ckan.plugins as p
 import ckan.lib.datapreview as datapreview
+from ckan.plugins.toolkit import h, _
 
 log = logging.getLogger(__name__)
 
@@ -37,7 +38,9 @@ class PdfView(p.SingletonPlugin):
 
     def configure(self, config):
         enabled = config.get('ckan.resource_proxy_enabled', False)
+        max_size =config.get('ckanext.pdfview.max_size', '2000000')
         self.proxy_is_enabled = enabled
+        self.custom_max_size = int(max_size)
 
     def can_view(self, data_dict):
         resource = data_dict['resource']
@@ -46,6 +49,10 @@ class PdfView(p.SingletonPlugin):
         proxy_enabled = p.plugin_loaded('resource_proxy')
         same_domain = datapreview.on_same_domain(data_dict)
 
+        pdf_size = resource.get('Size', 0)
+        if pdf_size > self.custom_max_size:
+            h.flash_notice(_('This PDF is too big for preview. Downloading the file is suggested'))
+            return False
         if format_lower in self.PDF:
             return same_domain or proxy_enabled
         return False

--- a/ckanext/pdfview/plugin.py
+++ b/ckanext/pdfview/plugin.py
@@ -2,7 +2,6 @@ import logging
 
 import ckan.plugins as p
 import ckan.lib.datapreview as datapreview
-from ckan.plugins.toolkit import h, _
 
 log = logging.getLogger(__name__)
 
@@ -38,9 +37,7 @@ class PdfView(p.SingletonPlugin):
 
     def configure(self, config):
         enabled = config.get('ckan.resource_proxy_enabled', False)
-        max_size =config.get('ckanext.pdfview.max_size', '2000000')
         self.proxy_is_enabled = enabled
-        self.custom_max_size = int(max_size)
 
     def can_view(self, data_dict):
         resource = data_dict['resource']
@@ -49,10 +46,6 @@ class PdfView(p.SingletonPlugin):
         proxy_enabled = p.plugin_loaded('resource_proxy')
         same_domain = datapreview.on_same_domain(data_dict)
 
-        pdf_size = resource.get('Size', 0)
-        if pdf_size > self.custom_max_size:
-            h.flash_notice(_('This PDF is too big for preview. Downloading the file is suggested'))
-            return False
         if format_lower in self.PDF:
             return same_domain or proxy_enabled
         return False

--- a/ckanext/pdfview/theme/public/vendor/pdfjs/web/viewer.js
+++ b/ckanext/pdfview/theme/public/vendor/pdfjs/web/viewer.js
@@ -4262,6 +4262,7 @@ var PDFViewer = (function pdfViewer() {
       var pagesCount = pdfDocument.numPages;
       var pagesRefMap = this.pagesRefMap = {};
       var self = this;
+      //the default value for oversize is false, the pdf file will be rendered
       self.oversize = false;
 
       var resolvePagesPromise;
@@ -4309,6 +4310,8 @@ var PDFViewer = (function pdfViewer() {
         var scale = this._currentScale || 1.0;
         var viewport = pdfPage.getViewport(scale * CSS_UNITS);
         this.oversize = window.oversize;
+        //if oversize is true, bindOnAfterAndBeforeDraw() will not be called
+        //and the pages will not be rendered which reduces server CPU usage
         if (this.oversize){
           return
         } else {
@@ -6109,9 +6112,11 @@ var PDFViewerApplication = {
     DocumentProperties.pdfDocument = pdfDocument;
     DocumentProperties.resolveDataAvailable();
 
+    //When getDownloadInfo() completed, the file size would be known
+    //if the file is larger than 3MB, set oversize to true
     pdfDocument.getDownloadInfo().then(function(data){
       if (data.length > 3000000){
-        self.error('This PDF is too large to be previewed in the browser. It is suggested to download.');
+        self.error('This PDF is too large to be previewed in the browser. It is suggested to download the PDF file.');
         window.oversize =true;
       }
     });


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [TICKET](https://opengovinc.atlassian.net/browse/PA-500)
## Description
<!--- Describe these changes in detail --->
Get the pdf size after pdf.js finish loading. After size comparison, if file too large (>3MB), prevent pdf.js rendering.

## Test Procedure
<!--- List the steps involved to test the changes --->
1.python setup.py develop
2.enable `pdf_view` in ckan.ini plugins
3.upload a pdf file larger than 3 MB to dataset and create a PDF view for it.
4.the pdf will fail rendering and give an error message.
5.if possible, test on sandbox to make sure CPU usage is low when refreshing the pdf view page(< 120mcores) on datadog or something alike, using 10-30MB pdf file suggested.

## Approval Criteria
<!--- Describe the expected results of testing --->

## Old python code description archived below in case needed
<!--- old --->

## Description
<!--- Describe these changes in detail --->
Added pdf size comparison in can_view function of plugin.py. When the pdf file is larger than 2MB (default), it will not be available for preview and will flash message to notify admin.

## Test Procedure
<!--- List the steps involved to test the changes --->
1.python setup.py develop
2.enable `pdf_view` in ckan.ini plugins
3.(optional)set "ckanext.pdfview.max_size = {a number} "(in bytes, for example, 2000000 for 2 MB) in ckan.ini, if not set, default is 2MB.
4.upload a pdf file to dataset and go to "manage", then go to "views" and click on `new view`

if file is too big, "pdf view" will not appear there and a notice message will flash (after refresh or going to another page). Vice versa.

(currently, 2 identical notice messages will flash because can_view function is called twice at the backend. Have not found a good way to solve this yet.)
## Approval Criteria
<!--- Describe the expected results of testing --->

## Submitter Checklist
- [ ] I have tested the changes locally
- [ ] The new changes does not affect web accessibility
